### PR TITLE
fix: Docker tags break with uppercase branches

### DIFF
--- a/src/io/stenic/jpipe/plugin/ConventionalCommitPlugin.groovy
+++ b/src/io/stenic/jpipe/plugin/ConventionalCommitPlugin.groovy
@@ -51,7 +51,7 @@ class ConventionalCommitPlugin extends Plugin {
                 return version
             }
 
-            return this.deduplicate(script, env.BRANCH_NAME.replaceAll('[^0-9a-zA-Z-]', '-'))
+            return this.deduplicate(script, env.BRANCH_NAME.replaceAll('[^0-9a-zA-Z-]', '-').toLowerCase())
         }
     }
 


### PR DESCRIPTION
Added .toLowerCase() to transform uppercase branch names to lowercase.