### PR TITLE
fix: Add ignoreMissing to sshagent calls

### DIFF
--- a/src/io/stenic/jpipe/plugin/ConventionalCommitPlugin.groovy
+++ b/src/io/stenic/jpipe/plugin/ConventionalCommitPlugin.groovy
@@ -97,7 +97,7 @@ class ConventionalCommitPlugin extends Plugin {
         ]
 
         script.withEnv(env) {
-            script.sshagent(credentials: [script.scm.getUserRemoteConfigs()[0].getCredentialsId()]) {
+            script.sshagent(credentials: [script.scm.getUserRemoteConfigs()[0].getCredentialsId()], ignoreMissing: true) {
                 script.sh "semantic-release ${cmdArgs}"
             }
         }

--- a/src/io/stenic/jpipe/plugin/DockerPlugin.groovy
+++ b/src/io/stenic/jpipe/plugin/DockerPlugin.groovy
@@ -68,7 +68,7 @@ class DockerPlugin extends Plugin {
             event.script.withEnv([
                 'DOCKER_BUILDKIT=1'
             ]) {
-                event.script.sshagent(credentials: [event.script.scm.getUserRemoteConfigs()[0].getCredentialsId()]) {
+                event.script.sshagent(credentials: [event.script.scm.getUserRemoteConfigs()[0].getCredentialsId(), ignoreMissing: true]) {
                     event.script.docker.build(
                         "${this.repository}:${event.version}",
                         "${buildArgs} --build-arg ${this.buildArgVersionKey}=${event.version} ${this.filePath}"

--- a/src/io/stenic/jpipe/plugin/DockerPlugin.groovy
+++ b/src/io/stenic/jpipe/plugin/DockerPlugin.groovy
@@ -68,7 +68,7 @@ class DockerPlugin extends Plugin {
             event.script.withEnv([
                 'DOCKER_BUILDKIT=1'
             ]) {
-                event.script.sshagent(credentials: [event.script.scm.getUserRemoteConfigs()[0].getCredentialsId(), ignoreMissing: true]) {
+                event.script.sshagent(credentials: [event.script.scm.getUserRemoteConfigs()[0].getCredentialsId()], ignoreMissing: true) {
                     event.script.docker.build(
                         "${this.repository}:${event.version}",
                         "${buildArgs} --build-arg ${this.buildArgVersionKey}=${event.version} ${this.filePath}"


### PR DESCRIPTION
Default ssh-agent behavior for missing credentials has changed: https://github.com/jenkinsci/ssh-agent-plugin/releases/tag/360.vf8027a_b_0c912
We need ignoreMissing to no longer fail pipelines where token credentials are used for SCM instead of a privateKey
